### PR TITLE
98 percent container width to lesson need for horizontal scrollbars

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,6 +17,9 @@
         font-family: 'Source Sans Pro', sans-serif;
         color: #2E2E30;
       }
+      .container {
+        max-width:98%;
+      }
 
       h1, h2 {
         font-family: 'Oswald', sans-serif;


### PR DESCRIPTION
Better use of space especially with the wide contents of the container row element that often causes a horizontal scroll bar to show up.